### PR TITLE
Small fix so that we don't try to merge term taxonomy ids when there aren't any merge.

### DIFF
--- a/components/class-go-related.php
+++ b/components/class-go-related.php
@@ -138,6 +138,11 @@ class GO_Related
 					continue;
 				}//end if
 
+				if ( ! is_array( $term_taxonomy_ids ) )
+				{
+					continue;
+				} // END if
+
 				$ttids = array_merge( $ttids, $term_taxonomy_ids );
 			}//end foreach
 


### PR DESCRIPTION
https://github.com/GigaOM/gigaom/issues/6438
