### PR TITLE
Update to ensure go-related always uses pre-determined matching articles

### DIFF
--- a/components/class-go-related.php
+++ b/components/class-go-related.php
@@ -20,20 +20,12 @@ class GO_Related
 	}//end widgets_init
 
 	/**
-	 * hooked to posts_distinct to make the query return distinct posts
-	 */
-	public function posts_distinct()
-	{
-		return 'DISTINCT';
-	}//end posts_distinct
-
-	/**
 	 * get related posts as a WP_Query
 	 */
 	public function get_related_posts( $post_id )
 	{
 		$params = array(
-			'posts_per_page' => 3,
+			'posts_per_page' => 5,
 			'ignore_sticky_posts' => TRUE,
 			'suppress_filters' => TRUE,
 		);
@@ -50,6 +42,7 @@ class GO_Related
 			$params['orderby'] = 'post__in';
 		}//end if
 
+		// this post has no pre-defined ralated posts, so grab some defaults
 		$query = new WP_Query( $params );
 
 		return $query;
@@ -60,122 +53,17 @@ class GO_Related
 	 */
 	private function get_related_post_ids( $post_id )
 	{
-		global $wpdb;
-
-		$post = get_post( $post_id );
-		$post_ids = array();
+		// most posts will have pre-assigned related posts that are assigned via a batch process
 		$ids = (array) get_post_meta( $post_id, 'go_related_stories_posts', TRUE );
 
-		if (
-			// try fetching from postmeta, make sure we have a current version of the array
-			! count( $ids['related_ids'] )
-			|| (
-				isset( $ids['created_date'] ) &&
-				// older than 2 hours?
-				$ids['created_date'] + 7200 < time()
-			)
-		)
-		{
-			$query = $this->get_related_posts_query( $post_id );
-
-			if ( ! $query )
-			{
-				return array();
-			}//end if
-
-			$post_ids = $wpdb->get_col( $query );
-
-			// save to postmeta
-			$ids = array(
-				'related_ids' => $post_ids,
-				'created_date' => time(),
-			);
-
-			update_post_meta( $post_id, 'go_related_stories_posts', $ids );
-		}// end if
+		// if this post does not have pre-assigned related posts, then use curated posts instead
+//		if ( empty( $ids )) {
+//			$ids = go_curated()
+//		}
 
 		return $ids;
 	}//end get_related_post_ids
 
-	/**
-	 * get related post query
-	 */
-	private function get_related_posts_query( $post_id )
-	{
-		global $wpdb;
-
-		// if there isn't a post id set, set it to 0
-		if ( ! ( $post_id = absint( $post_id ) ) )
-		{
-			$post_id = 0;
-		}//end if
-
-		$ttids = array();
-		$channel = NULL;
-
-		// if we have a legit post id, fetch the ttids and channel
-		if ( $post_id )
-		{
-			// get top 6 most popular terms on the post
-			if ( function_exists( 'go_taxonomy' ) )
-			{
-				$term_args = array(
-					'taxonomies' => array(
-						'technology',
-						'company',
-						'post_tag',
-						'person',
-					),
-					'number'  => 6,
-					'format'  => 'object',
-					'orderby' => 'name',
-					'order'   => 'ASC',
-				);
-
-				$terms = go_taxonomy()->sorted_terms( $post_id, $term_args );
-				$ttids = wp_list_pluck( $terms, 'term_taxonomy_id' );
-			}//end if
-
-			// let's try and grab the primary channel from the post as well
-			$channel = wp_list_pluck( get_the_terms( $post_id, 'primary_channel' ), 'term_taxonomy_id' );
-		}//end if
-
-		// if there isn't a primary channel, use the tech channel (example: attachments don't have primary channels)
-		if ( ! $channel )
-		{
-			$channel = get_term_by( 'slug', 'tech', 'primary_channel' );
-			$channel = array( absint( $channel->term_taxonomy_id ) );
-		}//end if
-
-		$pro_channel = get_term_by( 'slug', 'pro', 'primary_channel' );
-		$pro_channel = absint( $pro_channel->term_taxonomy_id );
-
-		// let's add the primary channel to the ttids array. this will cause every channel post to count as 1 hit
-		$ttids = array_merge( $ttids, $channel );
-
-		$query = "
-			SELECT t_r.object_id AS post_id, COUNT( t_r.object_id ) AS hits
-				FROM {$wpdb->term_relationships} t_r
-					LEFT JOIN {$wpdb->posts} p ON t_r.object_id  = p.ID
-				WHERE p.ID NOT IN( $post_id )
-					AND t_r.term_taxonomy_id IN (" . implode( $ttids, ',' ) . ")
-					AND p.post_status = 'publish'
-					AND p.post_type = 'post'
-					AND NOT EXISTS(
-						SELECT 1
-						FROM {$wpdb->term_relationships} t_r2
-						WHERE t_r2.object_id = p.ID
-							AND t_r2.term_taxonomy_id = %d
-					)
-				GROUP BY p.ID
-				ORDER BY hits DESC, p.post_date_gmt DESC
-				LIMIT 15
-		";
-
-		$query = $wpdb->prepare( $query, $pro_channel );
-
-		return $query;
-	}//end get_related_posts_query
 }//end class
 
 function go_related()

--- a/components/class-go-related.php
+++ b/components/class-go-related.php
@@ -25,44 +25,28 @@ class GO_Related
 	public function get_related_posts( $post_id )
 	{
 		$params = array(
-			'posts_per_page' => 5,
+			'posts_per_page' => 2,
 			'ignore_sticky_posts' => TRUE,
 			'suppress_filters' => TRUE,
 		);
 
-		$ids = $this->get_related_post_ids( $post_id );
+		// retrieve related post IDs.  these are pre-assigned via a batch process.
+		$ids = (array) get_post_meta( $post_id, 'go_related_stories_posts', TRUE );
 
-		// if there are related post ids, let's use those rather than the default loop
+		// if there are related posts, let's use those rather than the default loop
 		if ( ! empty( $ids['related_ids'] ) )
 		{
 			// merge and unique the batch
-			$ids = array_unique( $ids['related_ids'] );
+			$ids = shuffle(array_unique( $ids['related_ids'] ));
 
 			$params['post__in'] = $ids;
 			$params['orderby'] = 'post__in';
 		}//end if
 
-		// this post has no pre-defined ralated posts, so grab some defaults
 		$query = new WP_Query( $params );
 
 		return $query;
 	}//end get_related_posts
-
-	/**
-	 * get related post ids
-	 */
-	private function get_related_post_ids( $post_id )
-	{
-		// most posts will have pre-assigned related posts that are assigned via a batch process
-		$ids = (array) get_post_meta( $post_id, 'go_related_stories_posts', TRUE );
-
-		// if this post does not have pre-assigned related posts, then use curated posts instead
-//		if ( empty( $ids )) {
-//			$ids = go_curated()
-//		}
-
-		return $ids;
-	}//end get_related_post_ids
 
 }//end class
 

--- a/components/class-go-related.php
+++ b/components/class-go-related.php
@@ -24,29 +24,43 @@ class GO_Related
 	 */
 	public function get_related_posts( $post_id )
 	{
+		$num_related_posts = 2;
+
 		$params = array(
-			'posts_per_page' => 2,
+			'posts_per_page' => $num_related_posts,
 			'ignore_sticky_posts' => TRUE,
 			'suppress_filters' => TRUE,
 		);
 
-		// retrieve related post IDs.  these are pre-assigned via a batch process.
-		$ids = (array) get_post_meta( $post_id, 'go_related_stories_posts', TRUE );
+		$ids = $this->get_related_post_ids($post_id, $num_related_posts);
 
 		// if there are related posts, let's use those rather than the default loop
-		if ( ! empty( $ids['related_ids'] ) )
+		if ( ! empty( $ids ) )
 		{
-			// merge and unique the batch
-			$ids = shuffle(array_unique( $ids['related_ids'] ));
-
 			$params['post__in'] = $ids;
-			$params['orderby'] = 'post__in';
-		}//end if
+		}
 
 		$query = new WP_Query( $params );
 
 		return $query;
 	}//end get_related_posts
+
+	private function get_related_post_ids( $post_id, $num_related_posts )
+	{
+		// retrieve related post IDs.  these are pre-assigned via a batch process.
+		$related_meta = (array) get_post_meta( $post_id, 'go_related_stories_posts', TRUE );
+
+		if ( ! empty( $related_meta['related_ids'] ) ) {
+			// randomize available items for variety
+			$related_ids = $related_meta['related_ids'];
+			shuffle($related_ids);
+
+			// select specified number of ids from randomized list
+			$ids = array_slice($related_ids, 0, $num_related_posts);
+		}
+
+		return $ids;
+	}//end get_related_posts_ids
 
 }//end class
 


### PR DESCRIPTION
removed old related article caching and to always pull related articles from postmeta if available.  If no matches found, use default loop.  
